### PR TITLE
Add <label> to allow selecting answers via clicking on the text

### DIFF
--- a/includes/Question.php
+++ b/includes/Question.php
@@ -330,6 +330,7 @@ class Question {
 							break;
 					}
 					$signesOutput .= '<td class="sign">';
+					$attribs['id'] = $name;
 					$signesOutput .= Xml::input( $name, false, $value, $attribs );
 					$signesOutput .= '</td>';
 				}
@@ -357,9 +358,9 @@ class Question {
 			if ( $text !== null ) {
 				$lineOutput = '<tr class="' . $rawClass . '">' . "\n";
 				$lineOutput .= $signesOutput;
-				$lineOutput .= '<td' . $colSpan . '>';
+				$lineOutput .= '<td' . $colSpan . '><label for="'.$name.'">';
 				$lineOutput .= $this->mParser->recursiveTagParse( $text );
-				$lineOutput .= '</td>';
+				$lineOutput .= '</label></td>';
 				$lineOutput .= '</tr>' . "\n";
 				if ( $rawClass === 'correction selected' || $rawClass === 'correction unselected' ) {
 					if ( $proposalIndex === -1 ) {


### PR DESCRIPTION
This adds <label> tags to answers to allow selecting and deselecting answers via clicking on the text.

This is likely not the nicest way to do this - feel free to do it in some other way - but im not a php dev and i needed that to go live asap. Its currently in production on:
https://vowi.fsinf.at/wiki/TU_Wien:Vertrags-_und_Haftungsrecht_VU_(Gr%C3%B6bl)/TUWEL-Quizzes